### PR TITLE
Refactor route parameter access in [id].vue

### DIFF
--- a/content/ja/2.concepts/3.routing/.template/solutions/pages/posts/[id].vue
+++ b/content/ja/2.concepts/3.routing/.template/solutions/pages/posts/[id].vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 const route = useRoute()
-const id = computed(() => route.params.id)
+const id = route.params.id
 </script>
 
 <template>


### PR DESCRIPTION
## Changes
Changed `route.params.id` retrieval from `computed()` to direct reference.

## Reason
Since Vue Router's `route.params` is already reactive, there's no need to wrap it with `computed()`.
This makes the code simpler and more readable.

## Impact
None. It will continue to work the same way as before.